### PR TITLE
add shortcode for intotextbox proudly gemopst von ZER

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -282,6 +282,17 @@ li.active a, li.active a:hover {
   display: none;
 }
 
+
+.shortcode-infotextbox {
+  width: 100%;
+  padding: 15px;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  box-sizing: border-box;
+  background: #e6e6e6;
+  border-left: 6px solid gray;
+}
+
 /* inconsolata-regular - latin */
 @font-face {
   font-family: 'Inconsolata';

--- a/layouts/shortcodes/infotextbox.html
+++ b/layouts/shortcodes/infotextbox.html
@@ -1,0 +1,3 @@
+<div class="shortcode-infotextbox">
+	{{ .Inner | markdownify }}
+</div>


### PR DESCRIPTION
Dieser Code

```
{{< infotextbox >}}<p>Hello <strong>World!</strong></p>{{< /infotextbox >}}
```

Sieht so aus:

<img width="632" alt="grafik" src="https://user-images.githubusercontent.com/3995477/200417426-a11cd7c3-6051-4e31-991b-9c6a217f2a3e.png">

Mag auch Markdown.