### PR TITLE
fix css indentation of quotes and lists

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -282,6 +282,31 @@ li.active a, li.active a:hover {
   display: none;
 }
 
+@media screen and (max-width: 767px) {
+    .entry-content ul,
+  .entry-summary ul,
+  .comment-content ul,
+  .entry-content ol,
+  .entry-summary ol,
+  .comment-content ol {
+    margin-left: 1em;
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .entry-content ul,
+  .entry-summary ul,
+  .comment-content ul,
+  .entry-content ol,
+  .entry-summary ol,
+  .comment-content ol {
+    margin-left: 1.75em;
+  }
+}
+.entry-content blockquote:not(.alignleft):not(.alignright), .entry-summary blockquote, .comment-content blockquote {
+  margin-left: 0;
+}
+
 /* inconsolata-regular - latin */
 @font-face {
   font-family: 'Inconsolata';


### PR DESCRIPTION
Fix the identation of ul, ol, und quotes, see #12 

Examples:

**Before**

<img width="204" alt="grafik" src="https://user-images.githubusercontent.com/3995477/200676263-5ae654bd-b912-40e5-ba55-9e5c6bd50bf1.png">

**After**

<img width="181" alt="grafik" src="https://user-images.githubusercontent.com/3995477/200676202-42ebfd17-be4b-45d9-b752-d2370487185a.png">

**Before** 

<img width="166" alt="grafik" src="https://user-images.githubusercontent.com/3995477/200676465-47b45d8e-a644-49b3-885e-88857defd510.png">

**After**

<img width="142" alt="grafik" src="https://user-images.githubusercontent.com/3995477/200676676-95c7cf50-0a78-4600-a022-a1dbb1b0121e.png">

