### PR TITLE
add margin-left to sticky-post on small devices

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -297,13 +297,19 @@ li.active a, li.active a:hover {
 }
 
 @media screen and (max-width: 767px) {
-    .entry-content ul,
+  .entry-content ul,
   .entry-summary ul,
   .comment-content ul,
   .entry-content ol,
   .entry-summary ol,
   .comment-content ol {
     margin-left: 1em;
+  }
+}
+
+@media screen and (max-width: 56.875em) {
+  .sticky-post {
+    margin-left: 7.6923%;
   }
 }
 


### PR DESCRIPTION
**Vorher:**

﻿﻿
<img width="298" alt="grafik" src="https://user-images.githubusercontent.com/3995477/203162322-7826d3e4-c435-43ba-becc-e7479b35c31d.png">


**Nachher:**

<img width="294" alt="grafik" src="https://user-images.githubusercontent.com/3995477/203162334-591e09d0-fca4-44c6-8200-d34f936fa034.png">
